### PR TITLE
Add --with-privileges options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## v0.2.1 (unreleased)
+
+* Add `--wuth-privileges` option to `diff` and `check` commands.
+
+
 ## v0.2.0
 
 * Add `from` and `to` argument to `diff` command which makes it possible

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.1 (unreleased)
 
-* Add `--wuth-privileges` option to `diff` and `check` commands.
+* Add `--with-privileges` option to `diff` and `check` commands.
 
 
 ## v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tusker"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Michael P. Jung <michael.jung@terreon.de>"]
 license = "Unlicense"
 readme = "README.md"


### PR DESCRIPTION
Hi !

We just found out it was needed in some cases to get the privileges migrations.
Populating a new env using a migration without any privileges setted up do not suit enough our needs.

What do you think ?