### PR TITLE
Support recursive glob syntax in migration and schema discovery

### DIFF
--- a/tusker/__init__.py
+++ b/tusker/__init__.py
@@ -95,7 +95,7 @@ class Tusker:
         with self.createdb('schema') as schema_engine:
             with schema_engine.begin() as schema_cursor:
                 self.log('Creating original schema...')
-                for filename in sorted(glob(self.config.schema.filename)):
+                for filename in sorted(glob(self.config.schema.filename, recursive=True)):
                     self.log('- {}'.format(filename))
                     execute_sql_file(schema_cursor, filename)
             yield schema_engine
@@ -176,7 +176,7 @@ class Tusker:
     def _get_migrations(self):
         migrations = []
         if self.config.migrations.filename:
-            migrations = glob(self.config.migrations.filename)
+            migrations = glob(self.config.migrations.filename, recursive=True)
         else:
             migrations = [
                 os.path.join(self.config.migrations.directory, filename)


### PR DESCRIPTION
Allows for more options organizing schema definitions.

`glob` returns the relative path, so any recursively discovered
directory names will be included in the schema/migration sort order.