### PR TITLE
Set default migra configs

### DIFF
--- a/tusker/config.py
+++ b/tusker/config.py
@@ -18,6 +18,7 @@ class Config:
         data.setdefault('database', {'dbname': 'tusker'})
         data.setdefault('schema', {'filename': 'schema.sql'})
         data.setdefault('migrations', {'directory': 'migrations'})
+        data.setdefault('migra', {'safe': False, 'privileges': False})
         self.schema = SchemaConfig(data['schema'])
         self.migrations = MigrationsConfig(data['migrations'])
         self.database = DatabaseConfig(data['database'])


### PR DESCRIPTION
With the 0.4.3 release, running without a config file results in the following error:

```
tomlkit.exceptions.NonExistentKey: 'Key "migra" does not exist.'
```