### PR TITLE
Escape percent sign in SQL text

### DIFF
--- a/tusker/__init__.py
+++ b/tusker/__init__.py
@@ -40,7 +40,7 @@ def execute_sql_file(cursor, filename):
     if not sql:
         return
     try:
-        cursor.exec_driver_sql(sql)
+        cursor.exec_driver_sql(sql.replace('%', '%%'))
     except sqlalchemy.exc.SQLAlchemyError as e:
         # https://github.com/sqlalchemy/sqlalchemy/blob/9e7c068d669b209713da62da5748579f92d98129/lib/sqlalchemy/exc.py#L699-L709
         # To provide more detail on the underlying error, but without printing the original SQL.


### PR DESCRIPTION
Unescaped % signs in SQL text are treated as DB-API query parameters which is not what we need.

Closes: #21