### PR TITLE
Added ability for comma separated list filename patterns.

### DIFF
--- a/tusker/__init__.py
+++ b/tusker/__init__.py
@@ -109,9 +109,10 @@ class Tusker:
         with self.createdb('schema') as schema_engine:
             with schema_engine.begin() as schema_cursor:
                 self.log('Creating original schema...')
-                for filename in sorted(glob(self.config.schema.filename, recursive=True)):
-                    self.log('- {}'.format(filename))
-                    execute_sql_file(schema_cursor, filename)
+                for pattern in self.config.schema.filename.split(","):
+                    for filename in sorted(glob(pattern, recursive=True)):
+                        self.log('- {}'.format(filename))
+                        execute_sql_file(schema_cursor, filename)
             yield schema_engine
 
     @contextmanager


### PR DESCRIPTION
This PR adds the ability to specify a comma separate list of glob patterns for the schema.filename configuration.   Single pattern still works fine.

Example:

```
[schema]
filename = "schema/*.sql,procs/**/*.sql"
```