### PR TITLE
Added ability for list of patterns for filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 
-## v0.4.9
+## [Unreleased]
 * Added ability to specify schema.filename and migrations.filename as list
   of patterns used by glob to build the respective file lists. Defaults and
   backwards compatibility support of single string glob pattern

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Change Log
 
+
+## v0.4.9
+* Added ability to specify schema.filename and migrations.filename as list
+  of patterns used by glob to build the respective file lists. Defaults and
+  backwards compatibility support of single string glob pattern
+  still supported.
+
 ## v0.4.8
 
-* Fix "`ypeError: dict is not a sequence" error when
+* Fix "`TypeError: dict is not a sequence" error when
   the schema or migration files contain percent characters (`%`).
 
 ## v0.4.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 
 ## [Unreleased]
+
 * Added ability to specify schema.filename and migrations.filename as list
   of patterns used by glob to build the respective file lists. Defaults and
   backwards compatibility support of single string glob pattern
   still supported.
+* Add support for interpolated environment variables within config files.
 
 ## v0.4.8
 

--- a/tusker/__init__.py
+++ b/tusker/__init__.py
@@ -109,7 +109,7 @@ class Tusker:
         with self.createdb('schema') as schema_engine:
             with schema_engine.begin() as schema_cursor:
                 self.log('Creating original schema...')
-                for pattern in self.config.schema.filename.split(","):
+                for pattern in self.config.schema.filename:
                     for filename in sorted(glob(pattern, recursive=True)):
                         self.log('- {}'.format(filename))
                         execute_sql_file(schema_cursor, filename)

--- a/tusker/__init__.py
+++ b/tusker/__init__.py
@@ -191,7 +191,8 @@ class Tusker:
     def _get_migrations(self):
         migrations = []
         if self.config.migrations.filename:
-            migrations = glob(self.config.migrations.filename, recursive=True)
+            for pattern in self.config.migrations.filename:
+                migrations.extend(glob(pattern, recursive=True))
         else:
             migrations = [
                 os.path.join(self.config.migrations.directory, filename)

--- a/tusker/__init__.py
+++ b/tusker/__init__.py
@@ -109,9 +109,10 @@ class Tusker:
         with self.createdb('schema') as schema_engine:
             with schema_engine.begin() as schema_cursor:
                 self.log('Creating original schema...')
-                for filename in sorted(glob(self.config.schema.filename, recursive=True)):
-                    self.log('- {}'.format(filename))
-                    execute_sql_file(schema_cursor, filename)
+                for pattern in self.config.schema.filename.split(","):
+                    for filename in sorted(glob(pattern, recursive=True)):
+                        self.log('- {}'.format(filename))
+                        execute_sql_file(schema_cursor, filename)
             yield schema_engine
 
     @contextmanager

--- a/tusker/config.py
+++ b/tusker/config.py
@@ -50,17 +50,21 @@ class ConfigReader:
             raise ConfigError.invalid(name, 'Not of type {}'.format(type))
         return value
 
+    def get_list(self, name, required=False, default=None):
+        value = self.get(name, (str, list), required, default)
+        if isinstance(value, str):
+            value = [value]
+        else:
+            if value and not all(isinstance(x, str) for x in value):
+                raise ConfigError.invalid(name, 'Not a list of strings {}'.format(value))
+        return value
+
 
 class SchemaConfig:
 
     def __init__(self, data):
         data = ConfigReader(data, 'schema')
-        self.filename = data.get('filename', (str, list))
-        if isinstance(self.filename, str):
-            self.filename = [self.filename]
-        else:
-            if not all(isinstance(x, str) for x in self.filename):
-                raise ConfigError.invalid('filename', 'Not a list of strings {}'.format(self.filename))
+        self.filename = data.get_list('filename')
 
     def __str__(self):
         return 'SchemaConfig({!r})'.format(self.__dict__)
@@ -71,13 +75,7 @@ class MigrationsConfig:
     def __init__(self, data):
         data = ConfigReader(data, 'migrations')
         self.directory = data.get('directory', str, False)
-
-        self.filename = data.get('filename', (str, list))
-        if isinstance(self.filename, str):
-            self.filename = [self.filename]
-        else:
-            if not all(isinstance(x, str) for x in self.filename):
-                raise ConfigError.invalid('filename', 'Not a list of strings {}'.format(self.filename))
+        self.filename = data.get_list('filename')
 
         if not self.directory and not self.filename:
             self.directory = 'migrations'

--- a/tusker/config.py
+++ b/tusker/config.py
@@ -16,7 +16,7 @@ class Config:
             data = {}
         # time to validate some configuration variables
         data.setdefault('database', {'dbname': 'tusker'})
-        data.setdefault('schema', {'filename': 'schema.sql'})
+        data.setdefault('schema', {'filename': ['schema.sql']})
         data.setdefault('migrations', {'directory': 'migrations'})
         data.setdefault('migra', {'safe': False, 'privileges': False})
         self.schema = SchemaConfig(data['schema'])
@@ -55,7 +55,7 @@ class SchemaConfig:
 
     def __init__(self, data):
         data = ConfigReader(data, 'schema')
-        self.filename = data.get('filename', str) or 'schema.sql'
+        self.filename = data.get('filename', list) or ['schema.sql']
 
     def __str__(self):
         return 'SchemaConfig({!r})'.format(self.__dict__)

--- a/tusker/config.py
+++ b/tusker/config.py
@@ -54,8 +54,11 @@ class ConfigReader:
 class SchemaConfig:
 
     def __init__(self, data):
-        data = ConfigReader(data, 'schema')
-        self.filename = data.get('filename', list) or ['schema.sql']
+        config = ConfigReader(data, 'schema')
+        if isinstance(data['filename'], str):
+            self.filename = [config.get('filename', str)]
+        else:
+            self.filename = config.get('filename', list) or ['schema.sql']
 
     def __str__(self):
         return 'SchemaConfig({!r})'.format(self.__dict__)

--- a/tusker/config.py
+++ b/tusker/config.py
@@ -67,9 +67,14 @@ class SchemaConfig:
 class MigrationsConfig:
 
     def __init__(self, data):
-        data = ConfigReader(data, 'migrations')
-        self.directory = data.get('directory', str, False)
-        self.filename = data.get('filename', str, False)
+        config = ConfigReader(data, 'migrations')
+        self.directory = config.get('directory', str, False)
+
+        if isinstance(data['filename'], str):
+            self.filename = [config.get('filename', str)]
+        else:
+            self.filename = config.get('filename', list)
+            
         if not self.directory and not self.filename:
             self.directory = 'migrations'
         elif self.directory and self.filename:

--- a/tusker/config.py
+++ b/tusker/config.py
@@ -54,11 +54,13 @@ class ConfigReader:
 class SchemaConfig:
 
     def __init__(self, data):
-        config = ConfigReader(data, 'schema')
-        if isinstance(data['filename'], str):
-            self.filename = [config.get('filename', str)]
+        data = ConfigReader(data, 'schema')
+        self.filename = data.get('filename', (str, list))
+        if isinstance(self.filename, str):
+            self.filename = [self.filename]
         else:
-            self.filename = config.get('filename', list) or ['schema.sql']
+            if not all(isinstance(x, str) for x in self.filename):
+                raise ConfigError.invalid('filename', 'Not a list of strings {}'.format(self.filename))
 
     def __str__(self):
         return 'SchemaConfig({!r})'.format(self.__dict__)
@@ -67,14 +69,16 @@ class SchemaConfig:
 class MigrationsConfig:
 
     def __init__(self, data):
-        config = ConfigReader(data, 'migrations')
-        self.directory = config.get('directory', str, False)
+        data = ConfigReader(data, 'migrations')
+        self.directory = data.get('directory', str, False)
 
-        if isinstance(data['filename'], str):
-            self.filename = [config.get('filename', str)]
+        self.filename = data.get('filename', (str, list))
+        if isinstance(self.filename, str):
+            self.filename = [self.filename]
         else:
-            self.filename = config.get('filename', list)
-            
+            if not all(isinstance(x, str) for x in self.filename):
+                raise ConfigError.invalid('filename', 'Not a list of strings {}'.format(self.filename))
+
         if not self.directory and not self.filename:
             self.directory = 'migrations'
         elif self.directory and self.filename:


### PR DESCRIPTION
Added ability to specify a list in tusker.toml for schema.filename

```
[schema]
filename = ["schema/**/*.*sql","procs/**/*.pgsql"]
```

TODO: Backwards compatibility support for a single string.