### PR TITLE
Clarify usage of `dbname`, refs #32

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,9 +218,9 @@ marked with a `CREATED BY TUSKER` comment.
 
 ### What does the `dbname` setting in `tusker.toml` mean?
 
-The `dbname` setting in `tusker.toml` is used when diffing against your database.
-This command will print out the difference between the current database schema
-and the target schema:
+The `dbname` setting in `tusker.toml` specifies database name to be used when diffing
+against your database. This command will print out the difference between the current
+database schema and the target schema:
 
 ```shell
 tusker diff database
@@ -232,5 +232,6 @@ Tusker also needs to create temporary databases when diffing against the `schema
 and/or `migrations`. The two databases are called `{dbname}_{timestamp}_schema`
 and `{dbname}_{timestamp}_migrations`.
 
-If you do not specify a `dbname`, it will use the default database, which defaults
-to your current user name.
+The `dbname` setting overrides the database name in connection `url` (if specified).
+If you do not specify database name in `dbname` or in the connection `url`, it will
+use the default database, which defaults to the database user name.

--- a/README.md
+++ b/README.md
@@ -204,6 +204,12 @@ Yes. This feature has been added in 0.2. You can pass a `from` and `to`
 argument to the `tusker diff` command. Check the output of `tusker diff --help` for
 more details.
 
+### How can I export initial schema from an existing database?
+
+For exporting the initial schema you can use the native Postgres
+[pg_dump](https://www.postgresql.org/docs/current/app-pgdump.html) command with
+the `--schema-only` option.
+
 ### Tusker printed an error and left the temporary databases behind. How can I remove them?
 
 Run `tusker clean`. This will remove all databases which were created

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ filename = "migrations/*.sql"
 #port = 5432
 #user = ""
 #password = ""
-dbname = "tusker"
+dbname = "my_awesome_db"
 
 [migra]
 safe = false
@@ -140,7 +140,7 @@ filename = "schema.sql"
 filename = "migrations/*.sql"
 
 [database]
-url = "postgresql:///my_awesome_db"
+url = "postgresql:///my_awesome_db_connection"
 ```
 
 You can also use an environment variable in place of a hard-coded value:

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ filename = "migrations/*.sql"
 #user = ""
 #password = ""
 dbname = "my_awesome_db"
+#schema = "public"
 
 [migra]
 safe = false

--- a/README.md
+++ b/README.md
@@ -211,14 +211,19 @@ marked with a `CREATED BY TUSKER` comment.
 
 ### What does the `dbname` setting in `tusker.toml` mean?
 
-When diffing against a ready migrated database this database name is used. This
-command will print out the difference between the current database schema and
-the target schema:
+The `dbname` setting in `tusker.toml` is used when diffing against your database.
+This command will print out the difference between the current database schema
+and the target schema:
 
 ```shell
 tusker diff database
 ```
 
+Note that this command is meant to be run after you have migrated your database.
+
 Tusker also needs to create temporary databases when diffing against the `schema`
 and/or `migrations`. The two databases are called `{dbname}_{timestamp}_schema`
 and `{dbname}_{timestamp}_migrations`.
+
+If you do not specify a `dbname`, it will use the default database, which defaults
+to your current user name.

--- a/tusker.toml.example
+++ b/tusker.toml.example
@@ -2,11 +2,11 @@
 filename = "schema.sql"
 
 [migrations]
-directory = "migrations"
+filename = "migrations/*.sql"
 
 [database]
 #host = ""
-#port = ""
+#port = 5432
 #user = ""
 #password = ""
 dbname = "my_awesome_db"

--- a/tusker.toml.example
+++ b/tusker.toml.example
@@ -9,7 +9,7 @@ directory = "migrations"
 #port = ""
 #user = ""
 #password = ""
-dbname = "tusker"
+dbname = "my_awesome_db"
 #schema = "public"
 
 [migra]


### PR DESCRIPTION
Update README.md and example config to clarify usage of `dbname`.

Also changed:
* Sync `tusker.toml.example` and example config in `README.md`
* Add info how to export initial schema from an existing database

Related ticket: #32
